### PR TITLE
Add support for MFS thrust correction

### DIFF
--- a/MechJeb2/FuelFlowSimulation.cs
+++ b/MechJeb2/FuelFlowSimulation.cs
@@ -89,7 +89,7 @@ namespace MuMech
             foreach (FuelNode n in nodes) n.SetConsumptionRates(throttle, atmospheres);
 
             stats.startMass = VesselMass();
-            stats.startThrust = VesselThrust(throttle);
+            stats.startThrust = VesselThrust(throttle, atmospheres); // NK
 
             List<FuelNode> engines = FindActiveEngines();
 
@@ -185,9 +185,10 @@ namespace MuMech
             return nodes.Sum(n => n.Mass);
         }
 
-        public float VesselThrust(float throttle)
+        // NK change this to correct thrust
+        public float VesselThrust(float throttle, float atmospheres)
         {
-            return throttle * FindActiveEngines().Sum(eng => eng.maxThrust);
+                return throttle * FindActiveEngines().Sum(eng => (eng.maxThrust * (eng.correctThrust ? (eng.ispCurve.Evaluate(atmospheres) / eng.ispCurve.Evaluate(0)) : 1f)));
         }
 
         //Returns a list of engines that fire during the current simulated stage.
@@ -249,7 +250,8 @@ namespace MuMech
 
         const float DRAINED = 0.1f; //if a resource amount falls below this amount we say that the resource has been drained
 
-        FloatCurve ispCurve;                     //the function that gives Isp as a function of atmospheric pressure for this part, if it's an engine
+        public FloatCurve ispCurve;                     //the function that gives Isp as a function of atmospheric pressure for this part, if it's an engine (NK: make public)
+        public bool correctThrust = false; // NK
         Dictionary<int, float> propellantRatios; //ratios of propellants used by this engine
         float propellantSumRatioTimesDensity;    //a number used in computing propellant consumption rates
 
@@ -309,6 +311,15 @@ namespace MuMech
                     isActive = !engine.engineShutdown;
 
                     maxThrust = engine.maxThrust;
+                    // NK correct thrust
+                    if (part.Modules.Contains("ModuleEngineConfigs") || part.Modules.Contains("ModuleHybridEngine") || part.Modules.Contains("ModuleHybridEngines"))
+                    {
+                        correctThrust = true;
+                        if (HighLogic.LoadedSceneIsFlight && engine.realIsp > 0.0f)
+                            maxThrust = maxThrust * engine.atmosphereCurve.Evaluate(0) / engine.realIsp; //engine.atmosphereCurve.Evaluate((float)FlightGlobals.ActiveVessel.atmDensity);
+                    }
+                    else
+                        correctThrust = false;
                     ispCurve = engine.atmosphereCurve;
 
                     propellantSumRatioTimesDensity = engine.propellants.Sum(prop => prop.ratio * MuUtils.ResourceDensity(prop.id));
@@ -337,7 +348,8 @@ namespace MuMech
             if (isEngine)
             {
                 float Isp = ispCurve.Evaluate(atmospheres);
-                float massFlowRate = (throttle * maxThrust) / (Isp * 9.81f);
+                float massFlowRate = throttle * maxThrust / (Isp * 9.81f);
+                if(correctThrust) massFlowRate = massFlowRate * Isp / ispCurve.Evaluate(0); // NK scale thrust
 
                 //propellant consumption rate = ratio * massFlowRate / sum(ratio * density)
                 resourceConsumptions = propellantRatios.Keys.ToDictionary(id => id, id => propellantRatios[id] * massFlowRate / propellantSumRatioTimesDensity);

--- a/MechJeb2/MechJebModuleInfoItems.cs
+++ b/MechJeb2/MechJebModuleInfoItems.cs
@@ -619,6 +619,8 @@ namespace MuMech
         [Persistent(pass = (int)Pass.Global)]
         public bool showInitialTWR = true;
         [Persistent(pass = (int)Pass.Global)]
+        public bool showAtmoInitialTWR = false; // NK
+        [Persistent(pass = (int)Pass.Global)]
         public bool showMaxTWR = false;
         [Persistent(pass = (int)Pass.Global)]
         public bool showVacDeltaV = true;
@@ -645,14 +647,22 @@ namespace MuMech
             GUILayout.Label("Stage stats", GUILayout.ExpandWidth(true));
             if (GUILayout.Button("All stats", GUILayout.ExpandWidth(false)))
             {
+                // NK detect necessity of atmo initial TWR
+                bool hasMFE = false;
+                foreach (Part p in parts)
+                    if (p.Modules.Contains("ModuleEngineConfigs") || p.Modules.Contains("ModuleHybridEngine") || p.Modules.Contains("ModuleHybridEngines"))
+                        hasMFE = true;
+                // end
                 if (showInitialMass)
                 {
                     showInitialTWR = showVacDeltaV = showVacTime = showAtmoDeltaV = showAtmoTime = true;
+                    showAtmoInitialTWR = hasMFE; // NK
                     showInitialMass = showFinalMass = showMaxTWR = false;
                 }
                 else
                 {
                     showInitialMass = showInitialTWR = showMaxTWR = showVacDeltaV = showVacTime = showAtmoDeltaV = showAtmoTime = true;
+                    showAtmoInitialTWR = hasMFE; // NK
                 }
             }
             GUILayout.EndHorizontal();
@@ -664,6 +674,7 @@ namespace MuMech
             if (showInitialMass) showInitialMass = !DrawStageStatsColumn("Start mass", stages.Select(s => stats.vacStats[s].startMass.ToString("F1") + " t"));
             if (showFinalMass) showFinalMass = !DrawStageStatsColumn("End mass", stages.Select(s => stats.vacStats[s].endMass.ToString("F1") + " t"));
             if (showInitialTWR) showInitialTWR = !DrawStageStatsColumn("TWR", stages.Select(s => stats.vacStats[s].StartTWR(geeASL).ToString("F2")));
+            if (showAtmoInitialTWR) showAtmoInitialTWR = !DrawStageStatsColumn("SLT", stages.Select(s => stats.atmoStats[s].StartTWR(geeASL).ToString("F2"))); // NK
             if (showMaxTWR) showMaxTWR = !DrawStageStatsColumn("Max TWR", stages.Select(s => stats.vacStats[s].MaxTWR(geeASL).ToString("F2")));
             if (showAtmoDeltaV) showAtmoDeltaV = !DrawStageStatsColumn("Atmo ΔV", stages.Select(s => stats.atmoStats[s].deltaV.ToString("F0") + " m/s"));
             if (showAtmoTime) showAtmoTime = !DrawStageStatsColumn("Atmo time", stages.Select(s => GuiUtils.TimeToDHMS(stats.atmoStats[s].deltaTime)));


### PR DESCRIPTION
Adds new column in stats SLT (sea level TWR), only available if an MFS
engine is around. Also fixes run time for thrust correction.
